### PR TITLE
Use gcov version matching the gcc version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           - os: ubuntu-22.04
             compiler: gcc-11
             CMAKE_GENERATOR: "Unix Makefiles"
-            GCOV: gcov
+            GCOV: gcov-11
 
           - os: windows-2022
             compiler: msvc


### PR DESCRIPTION
This is the fix for aminya/setup-cpp#140 .

Temporary fix for aminya/setup-cpp#140 