### PR TITLE
use helper functions of `package_project` to find dependencies and include header directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,12 +102,7 @@ package_project(
   my_header_lib
   my_project_options
   my_project_warnings
-  INTERFACE_DEPENDENCIES_CONFIGURED
-  ${my_header_lib_DEPENDENCIES_CONFIGURED}
-  INTERFACE_INCLUDES
-  ${my_header_lib_INCLUDE_DIR}
-  PUBLIC_INCLUDES
-  ${my_lib_INCLUDE_DIR})
+)
 
 if(FEATURE_FUZZ_TESTS)
   add_subdirectory(fuzz_test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,20 +54,12 @@ if(FEATURE_TESTS)
   endif()
 
   add_library(catch2_test_common INTERFACE)
-  target_find_dependencies(catch2_test_common
-    INTERFACE_CONFIG
-    Catch2
-  )
-  target_link_libraries(catch2_test_common
-    INTERFACE
-    Catch2::Catch2
-  )
+  target_find_dependencies(catch2_test_common INTERFACE_CONFIG Catch2)
+  target_link_libraries(catch2_test_common INTERFACE Catch2::Catch2)
   # generate a main function for the test executable
   target_compile_definitions(catch2_test_common 
-    INTERFACE
-    CATCH_CONFIG_MAIN
-    DO_NOT_USE_WMAIN
-  )
+    INTERFACE CATCH_CONFIG_MAIN
+              DO_NOT_USE_WMAIN)
   include(Catch)
 endif()
 
@@ -118,8 +110,7 @@ package_project(
   my_lib
   my_header_lib
   my_project_options
-  my_project_warnings
-)
+  my_project_warnings)
 
 if(FEATURE_FUZZ_TESTS)
   add_subdirectory(fuzz_test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.16)
 # Change the version in the following URL to update the package (watch the releases of the repository for future updates)
 include(FetchContent)
 FetchContent_Declare(_project_options
-                     URL https://github.com/aminya/project_options/archive/refs/tags/v0.27.0.zip)
+                     URL https://github.com/aminya/project_options/archive/refs/tags/v0.27.1.zip)
 FetchContent_MakeAvailable(_project_options)
 include(${_project_options_SOURCE_DIR}/Index.cmake)
 
@@ -57,7 +57,7 @@ if(FEATURE_TESTS)
   target_find_dependencies(catch2_test_common INTERFACE_CONFIG Catch2)
   target_link_libraries(catch2_test_common INTERFACE Catch2::Catch2)
   # generate a main function for the test executable
-  target_compile_definitions(catch2_test_common 
+  target_compile_definitions(catch2_test_common
     INTERFACE CATCH_CONFIG_MAIN
               DO_NOT_USE_WMAIN)
   include(Catch)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,23 @@ if(FEATURE_TESTS)
       set(ENABLE_SANITIZER_ADDRESS "ENABLE_SANITIZER_ADDRESS")
     endif()
   endif()
+
+  add_library(catch2_test_common INTERFACE)
+  target_find_dependencies(catch2_test_common
+    INTERFACE_CONFIG
+    Catch2
+  )
+  target_link_libraries(catch2_test_common
+    INTERFACE
+    Catch2::Catch2
+  )
+  # generate a main function for the test executable
+  target_compile_definitions(catch2_test_common 
+    INTERFACE
+    CATCH_CONFIG_MAIN
+    DO_NOT_USE_WMAIN
+  )
+  include(Catch)
 endif()
 
 if(FEATURE_DOCS)

--- a/my_exe/CMakeLists.txt
+++ b/my_exe/CMakeLists.txt
@@ -5,53 +5,32 @@
 add_library(my_exe_lib INTERFACE) # use interface or normal library according to the implementation
 # link project_options/warnings
 target_link_libraries(my_exe_lib
-  INTERFACE
-  my_project_options
-  my_project_warnings
-)
+  INTERFACE my_project_options
+            my_project_warnings)
 
 # Includes
 target_include_interface_directories(my_exe_lib include)
 
 # Find dependencies:
-target_find_dependencies(my_exe_lib
-  INTERFACE_CONFIG
-  fmt
-)
+target_find_dependencies(my_exe_lib INTERFACE_CONFIG fmt)
 
 # Link dependencies:
-target_link_system_libraries(my_exe_lib
-  INTERFACE
-  fmt::fmt
-)
+target_link_system_libraries(my_exe_lib INTERFACE fmt::fmt)
 
 # ----------------------------------------------------------------------------------------------------------------------
 # executable part
 add_executable(my_exe "./src/main.cpp") # just for `main.cpp` which contains `main()` function
 # link project_options/warnings
-target_link_libraries(my_exe 
-  PRIVATE
-  my_project_options
-  my_project_warnings
-)
+target_link_libraries(my_exe PRIVATE my_project_options my_project_warnings)
 
 # Includes, just link the library part
-target_link_libraries(my_exe
-  PRIVATE
-  my_exe_lib
-)
+target_link_libraries(my_exe PRIVATE my_exe_lib)
 
 # Find dependencies:
-target_find_dependencies(my_exe
-  PRIVATE_CONFIG
-  fmt
-)
+target_find_dependencies(my_exe PRIVATE_CONFIG fmt)
 
 # Link dependencies
-target_link_system_libraries(my_exe
-  PRIVATE
-  fmt::fmt
-)
+target_link_system_libraries(my_exe PRIVATE fmt::fmt)
 
 # ----------------------------------------------------------------------------------------------------------------------
 # tests

--- a/my_exe/CMakeLists.txt
+++ b/my_exe/CMakeLists.txt
@@ -6,8 +6,8 @@ add_library(my_exe_lib INTERFACE) # use interface or normal library according to
 # link project_options/warnings
 target_link_libraries(my_exe_lib
   INTERFACE
-  project_options
-  project_warnings
+  my_project_options
+  my_project_warnings
 )
 
 # Includes

--- a/my_exe/CMakeLists.txt
+++ b/my_exe/CMakeLists.txt
@@ -1,26 +1,60 @@
-add_executable(my_exe "./src/main.cpp")
-target_link_libraries(my_exe PRIVATE my_project_options my_project_warnings) # link project_options/warnings
+# Seperate library part and executable part (`main()` function) to simplify testing.
+
+# ----------------------------------------------------------------------------------------------------------------------
+# library part
+add_library(my_exe_lib INTERFACE) # use interface or normal library according to the implementation
+# link project_options/warnings
+target_link_libraries(my_exe_lib
+  INTERFACE
+  project_options
+  project_warnings
+)
 
 # Includes
-# because my_exe includes are private, it uses absolute paths.
-set(my_exe_INCLUDE_DIR
-    "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    CACHE STRING "")
-target_include_directories(my_exe PRIVATE "${my_exe_INCLUDE_DIR}")
+target_include_interface_directories(my_exe_lib include)
 
 # Find dependencies:
-set(my_exe_DEPENDENCIES_CONFIGURED
-    fmt
-    CACHE STRING "")
+target_find_dependencies(my_exe_lib
+  INTERFACE_CONFIG
+  fmt
+)
 
-foreach(DEPENDENCY ${my_exe_DEPENDENCIES_CONFIGURED})
-  find_package(${DEPENDENCY} CONFIG REQUIRED)
-endforeach()
+# Link dependencies:
+target_link_system_libraries(my_exe_lib
+  INTERFACE
+  fmt::fmt
+)
+
+# ----------------------------------------------------------------------------------------------------------------------
+# executable part
+add_executable(my_exe "./src/main.cpp") # just for `main.cpp` which contains `main()` function
+# link project_options/warnings
+target_link_libraries(my_exe 
+  PRIVATE
+  my_project_options
+  my_project_warnings
+)
+
+# Includes, just link the library part
+target_link_libraries(my_exe
+  PRIVATE
+  my_exe_lib
+)
+
+# Find dependencies:
+target_find_dependencies(my_exe
+  PRIVATE_CONFIG
+  fmt
+)
 
 # Link dependencies
-set(my_exe_LINKED_LIBRARIES fmt::fmt)
-target_link_system_libraries(my_exe PRIVATE ${my_exe_LINKED_LIBRARIES})
+target_link_system_libraries(my_exe
+  PRIVATE
+  fmt::fmt
+)
 
+# ----------------------------------------------------------------------------------------------------------------------
+# tests
 if(FEATURE_TESTS)
   add_subdirectory("./test")
 endif()

--- a/my_exe/test/CMakeLists.txt
+++ b/my_exe/test/CMakeLists.txt
@@ -1,36 +1,30 @@
 # test dependencies
-set(tests_DEPENDENCIES_CONFIGURED Catch2)
-
-foreach(DEPENDENCY ${tests_DEPENDENCIES_CONFIGURED})
-  find_package(${DEPENDENCY} CONFIG REQUIRED)
-endforeach()
-
 include(CTest)
-include(Catch)
 
-# calling my_exe executable directly
-add_test(
+# ----------------------------------------------------------------------------------------------------------------------
+# test the executable part
+add_test( # calling my_exe executable directly
   NAME my_exe_test
   COMMAND my_exe ""
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
 
-# testing helpers
-add_executable(my_exe_helpers_tests "./tests.cpp")
-
-# because my_exe helpers and dependencies are private, we should link them here again
-target_include_directories(my_exe_helpers_tests PRIVATE "${my_exe_INCLUDE_DIR}")
-
+# ----------------------------------------------------------------------------------------------------------------------
+# test the library part
+add_executable(my_exe_lib_tests "./tests.cpp")
 target_link_libraries(
-  my_exe_helpers_tests
-  PRIVATE my_project_warnings
-          my_project_options
-          Catch2::Catch2
-          ${my_exe_LINKED_LIBRARIES})
-
-# generate a main function for the test executable
-target_compile_definitions(my_exe_helpers_tests PRIVATE CATCH_CONFIG_MAIN DO_NOT_USE_WMAIN)
+  my_exe_lib_tests
+  PRIVATE
+  my_project_warnings
+  my_project_options
+  catch2_test_common
+  my_exe_lib
+)
 
 # use xml reporter if coverage is enabled
 if(${ENABLE_COVERAGE})
   set(COVERAGE_ARGS REPORTER xml)
 endif()
+
+# automatically discover tests that are defined in catch based test files you can modify the tests
+catch_discover_tests(my_exe_lib_tests ${COVERAGE_ARGS})

--- a/my_exe/test/CMakeLists.txt
+++ b/my_exe/test/CMakeLists.txt
@@ -6,20 +6,17 @@ include(CTest)
 add_test( # calling my_exe executable directly
   NAME my_exe_test
   COMMAND my_exe ""
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 # ----------------------------------------------------------------------------------------------------------------------
 # test the library part
 add_executable(my_exe_lib_tests "./tests.cpp")
 target_link_libraries(
   my_exe_lib_tests
-  PRIVATE
-  my_project_warnings
-  my_project_options
-  catch2_test_common
-  my_exe_lib
-)
+  PRIVATE my_project_warnings
+          my_project_options
+          catch2_test_common
+          my_exe_lib)
 
 # use xml reporter if coverage is enabled
 if(${ENABLE_COVERAGE})

--- a/my_header_lib/CMakeLists.txt
+++ b/my_header_lib/CMakeLists.txt
@@ -1,25 +1,17 @@
 add_library(my_header_lib INTERFACE)
 # link project_options/warnings
 target_link_libraries(my_header_lib
-  INTERFACE
-  my_project_options
-  my_project_warnings
-)
+  INTERFACE my_project_options
+            my_project_warnings)
 
 # Includes
 target_include_interface_directories(my_header_lib include)
 
 # Find dependencies:
-target_find_dependencies(my_header_lib
-  INTERFACE_CONFIG
-  fmt
-)
+target_find_dependencies(my_header_lib INTERFACE_CONFIG fmt)
 
 # Link dependencies:
-target_link_system_libraries(my_header_lib
-  INTERFACE
-  fmt::fmt
-)
+target_link_system_libraries(my_header_lib INTERFACE fmt::fmt)
 
 if(FEATURE_TESTS)
   add_subdirectory("./test")

--- a/my_header_lib/CMakeLists.txt
+++ b/my_header_lib/CMakeLists.txt
@@ -1,25 +1,25 @@
 add_library(my_header_lib INTERFACE)
-target_link_libraries(my_header_lib INTERFACE my_project_options my_project_warnings
-)# link project_options/warnings
+# link project_options/warnings
+target_link_libraries(my_header_lib
+  INTERFACE
+  my_project_options
+  my_project_warnings
+)
 
 # Includes
-set(my_header_lib_INCLUDE_DIR
-    "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    CACHE STRING "")
-target_include_directories(my_header_lib INTERFACE "$<BUILD_INTERFACE:${my_header_lib_INCLUDE_DIR}>"
-                                                   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
+target_include_interface_directories(my_header_lib include)
 
 # Find dependencies:
-set(my_header_lib_DEPENDENCIES_CONFIGURED
-    fmt
-    CACHE STRING "")
-
-foreach(DEPENDENCY ${my_header_lib_DEPENDENCIES_CONFIGURED})
-  find_package(${DEPENDENCY} CONFIG REQUIRED)
-endforeach()
+target_find_dependencies(my_header_lib
+  INTERFACE_CONFIG
+  fmt
+)
 
 # Link dependencies:
-target_link_system_libraries(my_header_lib INTERFACE fmt::fmt)
+target_link_system_libraries(my_header_lib
+  INTERFACE
+  fmt::fmt
+)
 
 if(FEATURE_TESTS)
   add_subdirectory("./test")

--- a/my_header_lib/test/CMakeLists.txt
+++ b/my_header_lib/test/CMakeLists.txt
@@ -1,25 +1,17 @@
 # test dependencies
-set(tests_DEPENDENCIES_CONFIGURED Catch2)
-
-foreach(DEPENDENCY ${tests_DEPENDENCIES_CONFIGURED})
-  find_package(${DEPENDENCY} CONFIG REQUIRED)
-endforeach()
-
 include(CTest)
-include(Catch)
 
 # test executable
-
 add_executable(my_header_lib_tests "./tests.cpp")
 
 target_link_libraries(
   my_header_lib_tests
-  PRIVATE my_header_lib
-          my_project_warnings
-          my_project_options
-          Catch2::Catch2)
-# generate a main function for the test executable
-target_compile_definitions(my_header_lib_tests PRIVATE CATCH_CONFIG_MAIN DO_NOT_USE_WMAIN)
+  PRIVATE
+  my_header_lib
+  my_project_warnings
+  my_project_options
+  catch2_test_common
+)
 
 # use xml reporter if coverage is enabled
 if(${ENABLE_COVERAGE})

--- a/my_header_lib/test/CMakeLists.txt
+++ b/my_header_lib/test/CMakeLists.txt
@@ -6,12 +6,10 @@ add_executable(my_header_lib_tests "./tests.cpp")
 
 target_link_libraries(
   my_header_lib_tests
-  PRIVATE
-  my_header_lib
-  my_project_warnings
-  my_project_options
-  catch2_test_common
-)
+  PRIVATE my_header_lib
+          my_project_warnings
+          my_project_options
+          catch2_test_common)
 
 # use xml reporter if coverage is enabled
 if(${ENABLE_COVERAGE})

--- a/my_header_lib/test/constexpr/CMakeLists.txt
+++ b/my_header_lib/test/constexpr/CMakeLists.txt
@@ -3,12 +3,10 @@ add_executable(my_header_lib_constexpr_tests "./constexpr_tests.cpp")
 
 target_link_libraries(
   my_header_lib_constexpr_tests
-  PRIVATE
-  my_header_lib
-  my_project_warnings
-  my_project_options
-  catch2_test_common
-)
+  PRIVATE my_header_lib
+          my_project_warnings
+          my_project_options
+          catch2_test_common)
 
 catch_discover_tests(my_header_lib_constexpr_tests ${COVERAGE_ARGS})
 
@@ -18,12 +16,10 @@ add_executable(my_header_lib_relaxed_constexpr_tests "./constexpr_tests.cpp")
 
 target_link_libraries(
   my_header_lib_relaxed_constexpr_tests
-  PRIVATE
-  my_header_lib
-  my_project_warnings
-  my_project_options
-  catch2_test_common
-)
+  PRIVATE my_header_lib
+          my_project_warnings
+          my_project_options
+          catch2_test_common)
 target_compile_definitions(my_header_lib_relaxed_constexpr_tests
   PRIVATE -DCATCH_CONFIG_RUNTIME_STATIC_REQUIRE)
 

--- a/my_header_lib/test/constexpr/CMakeLists.txt
+++ b/my_header_lib/test/constexpr/CMakeLists.txt
@@ -3,11 +3,12 @@ add_executable(my_header_lib_constexpr_tests "./constexpr_tests.cpp")
 
 target_link_libraries(
   my_header_lib_constexpr_tests
-  PRIVATE my_header_lib
-          my_project_warnings
-          my_project_options
-          Catch2::Catch2)
-target_compile_definitions(my_header_lib_constexpr_tests PRIVATE CATCH_CONFIG_MAIN DO_NOT_USE_WMAIN)
+  PRIVATE
+  my_header_lib
+  my_project_warnings
+  my_project_options
+  catch2_test_common
+)
 
 catch_discover_tests(my_header_lib_constexpr_tests ${COVERAGE_ARGS})
 
@@ -17,12 +18,13 @@ add_executable(my_header_lib_relaxed_constexpr_tests "./constexpr_tests.cpp")
 
 target_link_libraries(
   my_header_lib_relaxed_constexpr_tests
-  PRIVATE my_header_lib
-          my_project_warnings
-          my_project_options
-          Catch2::Catch2)
-target_compile_definitions(my_header_lib_relaxed_constexpr_tests PRIVATE CATCH_CONFIG_MAIN DO_NOT_USE_WMAIN)
+  PRIVATE
+  my_header_lib
+  my_project_warnings
+  my_project_options
+  catch2_test_common
+)
 target_compile_definitions(my_header_lib_relaxed_constexpr_tests
-                           PRIVATE -DCATCH_CONFIG_RUNTIME_STATIC_REQUIRE)
+  PRIVATE -DCATCH_CONFIG_RUNTIME_STATIC_REQUIRE)
 
 catch_discover_tests(my_header_lib_relaxed_constexpr_tests ${COVERAGE_ARGS})

--- a/my_lib/CMakeLists.txt
+++ b/my_lib/CMakeLists.txt
@@ -1,25 +1,17 @@
 add_library(my_lib "./src/my_lib/lib.cpp")
 # link project_options/warnings
 target_link_libraries(my_lib
-  PRIVATE
-  my_project_options
-  my_project_warnings
-)
+  PRIVATE my_project_options
+          my_project_warnings)
 
 # Includes
 target_include_interface_directories(my_lib include)
 
 # Find dependencies:
-target_find_dependencies(my_lib
-  PRIVATE_CONFIG
-  fmt
-)
+target_find_dependencies(my_lib PRIVATE_CONFIG fmt)
 
 # Link dependencies:
-target_link_system_libraries(my_lib
-  PRIVATE
-  fmt::fmt
-)
+target_link_system_libraries(my_lib PRIVATE fmt::fmt)
 
 if(FEATURE_TESTS)
   add_subdirectory("./test")

--- a/my_lib/CMakeLists.txt
+++ b/my_lib/CMakeLists.txt
@@ -1,24 +1,25 @@
 add_library(my_lib "./src/my_lib/lib.cpp")
-target_link_libraries(my_lib PRIVATE my_project_options my_project_warnings) # link project_options/warnings
+# link project_options/warnings
+target_link_libraries(my_lib
+  PRIVATE
+  my_project_options
+  my_project_warnings
+)
 
 # Includes
-set(my_lib_INCLUDE_DIR
-    "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    CACHE STRING "")
-target_include_directories(my_lib PUBLIC "$<BUILD_INTERFACE:${my_lib_INCLUDE_DIR}>"
-                                         "$<INSTALL_INTERFACE:./${CMAKE_INSTALL_INCLUDEDIR}>")
+target_include_interface_directories(my_lib include)
 
 # Find dependencies:
-set(my_lib_DEPENDENCIES_CONFIGURED
-    fmt
-    CACHE STRING "")
-
-foreach(DEPENDENCY ${my_lib_DEPENDENCIES_CONFIGURED})
-  find_package(${DEPENDENCY} CONFIG REQUIRED)
-endforeach()
+target_find_dependencies(my_lib
+  PRIVATE_CONFIG
+  fmt
+)
 
 # Link dependencies:
-target_link_system_libraries(my_lib PRIVATE fmt::fmt)
+target_link_system_libraries(my_lib
+  PRIVATE
+  fmt::fmt
+)
 
 if(FEATURE_TESTS)
   add_subdirectory("./test")

--- a/my_lib/test/CMakeLists.txt
+++ b/my_lib/test/CMakeLists.txt
@@ -1,25 +1,16 @@
 # test dependencies
-set(tests_DEPENDENCIES_CONFIGURED Catch2)
-
-foreach(DEPENDENCY ${tests_DEPENDENCIES_CONFIGURED})
-  find_package(${DEPENDENCY} CONFIG REQUIRED)
-endforeach()
-
 include(CTest)
-include(Catch)
 
 # test executable
-
 add_executable(my_lib_tests "./tests.cpp")
 
 target_link_libraries(
   my_lib_tests
   PRIVATE my_lib
-          my_project_warnings
-          my_project_options
-          Catch2::Catch2)
-# generate a main function for the test executable
-target_compile_definitions(my_lib_tests PRIVATE CATCH_CONFIG_MAIN DO_NOT_USE_WMAIN)
+  my_project_warnings
+  my_project_options
+  catch2_test_common
+)
 
 # use xml reporter if coverage is enabled
 if(${ENABLE_COVERAGE})

--- a/my_lib/test/CMakeLists.txt
+++ b/my_lib/test/CMakeLists.txt
@@ -7,10 +7,9 @@ add_executable(my_lib_tests "./tests.cpp")
 target_link_libraries(
   my_lib_tests
   PRIVATE my_lib
-  my_project_warnings
-  my_project_options
-  catch2_test_common
-)
+          my_project_warnings
+          my_project_options
+          catch2_test_common)
 
 # use xml reporter if coverage is enabled
 if(${ENABLE_COVERAGE})

--- a/my_lib/test/constexpr/CMakeLists.txt
+++ b/my_lib/test/constexpr/CMakeLists.txt
@@ -3,11 +3,12 @@ add_executable(my_lib_constexpr_tests "./constexpr_tests.cpp")
 
 target_link_libraries(
   my_lib_constexpr_tests
-  PRIVATE my_lib
-          my_project_warnings
-          my_project_options
-          Catch2::Catch2)
-target_compile_definitions(my_lib_constexpr_tests PRIVATE CATCH_CONFIG_MAIN DO_NOT_USE_WMAIN)
+  PRIVATE
+  my_lib
+  my_project_warnings
+  my_project_options
+  catch2_test_common
+)
 
 catch_discover_tests(my_lib_constexpr_tests ${COVERAGE_ARGS})
 
@@ -17,11 +18,12 @@ add_executable(my_lib_relaxed_constexpr_tests "./constexpr_tests.cpp")
 
 target_link_libraries(
   my_lib_relaxed_constexpr_tests
-  PRIVATE my_lib
-          my_project_warnings
-          my_project_options
-          Catch2::Catch2)
-target_compile_definitions(my_lib_relaxed_constexpr_tests PRIVATE CATCH_CONFIG_MAIN DO_NOT_USE_WMAIN)
+  PRIVATE
+  my_lib
+  my_project_warnings
+  my_project_options
+  catch2_test_common
+)
 target_compile_definitions(my_lib_relaxed_constexpr_tests PRIVATE -DCATCH_CONFIG_RUNTIME_STATIC_REQUIRE)
 
 catch_discover_tests(my_lib_relaxed_constexpr_tests ${COVERAGE_ARGS})

--- a/my_lib/test/constexpr/CMakeLists.txt
+++ b/my_lib/test/constexpr/CMakeLists.txt
@@ -3,12 +3,10 @@ add_executable(my_lib_constexpr_tests "./constexpr_tests.cpp")
 
 target_link_libraries(
   my_lib_constexpr_tests
-  PRIVATE
-  my_lib
-  my_project_warnings
-  my_project_options
-  catch2_test_common
-)
+  PRIVATE my_lib
+          my_project_warnings
+          my_project_options
+          catch2_test_common)
 
 catch_discover_tests(my_lib_constexpr_tests ${COVERAGE_ARGS})
 
@@ -18,12 +16,10 @@ add_executable(my_lib_relaxed_constexpr_tests "./constexpr_tests.cpp")
 
 target_link_libraries(
   my_lib_relaxed_constexpr_tests
-  PRIVATE
-  my_lib
-  my_project_warnings
-  my_project_options
-  catch2_test_common
-)
+  PRIVATE my_lib
+          my_project_warnings
+          my_project_options
+          catch2_test_common)
 target_compile_definitions(my_lib_relaxed_constexpr_tests PRIVATE -DCATCH_CONFIG_RUNTIME_STATIC_REQUIRE)
 
 catch_discover_tests(my_lib_relaxed_constexpr_tests ${COVERAGE_ARGS})


### PR DESCRIPTION
Apply aminya/project_options#199 (a newer version in aminya/project_options#202).

As a side effect, seperate executable to library part and executable part. The executable part adds `main.cpp` (which contains the `main()` function) and links the library part; the library part adds all other headers and sources. By this seperation, the executable is easy to test. Learnt from [Modern-CMake-for-Cpp](https://github.com/PacktPublishing/Modern-CMake-for-Cpp).