### PR TITLE
Update CMakePresets.json

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -33,6 +33,7 @@
                 "strategy": "external"
             },
             "cacheVariables": {
+                "CMAKE_SYSTEM_PROCESSOR": "x64",
                 "ENABLE_CPPCHECK_DEFAULT": "FALSE",
                 "ENABLE_CLANG_TIDY_DEFAULT": "FALSE"
             }


### PR DESCRIPTION
set 	"CMAKE_SYSTEM_PROCESSOR": "x64" to prevent setup problems with WindowsToolchain